### PR TITLE
Fixed Vue & Marked js error to make the readme workable

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -157,7 +157,7 @@ const Preview = new Vue({
     compile: function(section) {
       var text = this.sections[section].replace(/^[\s]*=[\s]+(.+?)[\s]+=/gm, '#### $1' );
 
-      return marked( text, { sanitize: false } );
+      return marked.parse( text, { sanitize: false } );
     },
 
     transform: function(index) {

--- a/index.html
+++ b/index.html
@@ -5,6 +5,8 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>WordPress Readme Generator</title>
+    
+    <link rel="icon" type="image/x-icon" href="https://upload.wikimedia.org/wikipedia/commons/thumb/9/98/WordPress_blue_logo.svg/240px-WordPress_blue_logo.svg.png">
 
     <meta property="og:site_name" content="WordPress Readme Generator" />
     <meta property="og:url" content="https://tools.wedevs.com/readme/" />

--- a/index.html
+++ b/index.html
@@ -200,7 +200,7 @@
     </div>
     <div id="modal-backdrop" class="modal-backdrop"></div>
 
-    <script src="https://unpkg.com/vue@3.2.31/dist/vue.global.js"></script>
+    <script src="https://unpkg.com/vue@2.6.14/dist/vue.js"></script>
     <script src="https://unpkg.com/jquery@3.6.0/dist/jquery.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
     <script src="https://unpkg.com/underscore@1.13.2/underscore-umd.js"></script>

--- a/index.html
+++ b/index.html
@@ -200,10 +200,10 @@
     </div>
     <div id="modal-backdrop" class="modal-backdrop"></div>
 
-    <script src="https://unpkg.com/vue"></script>
-    <script src="https://unpkg.com/jquery"></script>
+    <script src="https://unpkg.com/vue@3.2.31/dist/vue.global.js"></script>
+    <script src="https://unpkg.com/jquery@3.6.0/dist/jquery.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
-    <script src="https://unpkg.com/underscore"></script>
+    <script src="https://unpkg.com/underscore@1.13.2/underscore-umd.js"></script>
     <script src="assets/js/script.js?v=16"></script>
 
     <script>


### PR DESCRIPTION
There was Vue and Marked js error that has been fixed by changing the Vue.js CDN link and redeclaring the marked function. Also, this PR added WordPress blue logo as a favicon.